### PR TITLE
Fix typos

### DIFF
--- a/static/html/about.html
+++ b/static/html/about.html
@@ -29,7 +29,7 @@
             Nginx, but things are constantly changing so that might not be the case anymore!
           </p>
           <p>
-            If you want to find out more about the projects I'm currently working on, make sure to check out my Github. For contacting me you can always
+            If you want to find out more about the projects I'm currently working on, make sure to check out my GitHub. For contacting me you can always
             reach me using email or find me on various IRC channels ("UndeadLeech" on freenode). You can find my public PGP key and email address
             <a href="http://pgp.mit.edu/pks/lookup?op=vindex&search=0x85CDAE3C164BA7B4">
               <span class="link-title">pgp-key</span>
@@ -40,11 +40,11 @@
         <div class="columns">
           <a href="https://github.com/chrisduerr" target="_blank">
             <span class="link-title">github</span>
-            Github
+            GitHub
           </a>
           <a href="https://gitlab.com/chrisduerr" target="_blank">
           <span class="link-title">gitlab</span>
-            Gitlab
+            GitLab
           </a>
         </div>
       </div>

--- a/static/html/projects-1.html
+++ b/static/html/projects-1.html
@@ -30,11 +30,11 @@
               <div class="columns">
                 <a href="https://github.com/jwilm/alacritty">
                   <span class="link-title">alacritty-upstream</span>
-                  Upstream Github
+                  Upstream GitHub
                 </a>
                 <a href="https://github.com/chrisduerr/alacritty">
                   <span class="link-title">alacritty-fork</span>
-                  Fork Github
+                  Fork GitHub
                 </a>
               </div>
             </div>

--- a/static/html/projects.html
+++ b/static/html/projects.html
@@ -27,11 +27,11 @@
               <div class="columns">
                 <a href="https://github.com/chrisduerr/userstyles" target="_blank">
                   <span class="link-title">userstyles-github</span>
-                  Github
+                  GitHub
                 </a>
                 <a href="https://gitlab.com/chrisduerr/userstyles" target="_blank">
                   <span class="link-title">userstyles-gitlab</span>
-                  Gitlab
+                  GitLab
                 </a>
               </div>
             </div>
@@ -51,11 +51,11 @@
               <div class="columns">
                 <a href="https://github.com/chrisduerr/dotfiles">
                   <span class="link-title">dotfiles-github</span>
-                  Github
+                  GitHub
                 </a>
                 <a href="https://gitlab.com/chrisduerr/dotfiles">
                   <span class="link-title">dotfiles-gitlab</span>
-                  Gitlab
+                  GitLab
                 </a>
               </div>
             </div>
@@ -75,7 +75,7 @@
               <div class="columns">
                 <a href="https://github.com/chrisduerr/website">
                   <span class="link-title">website-github</span>
-                  Github
+                  GitHub
                 </a>
                 <a href="https://christianduerr.com">
                   <span class="link-title">website</span>
@@ -83,7 +83,7 @@
                 </a>
                 <a href="https://gitlab.com/chrisduerr/website">
                   <span class="link-title">website-gitlab</span>
-                  Gitlab
+                  GitLab
                 </a>
               </div>
             </div>
@@ -105,11 +105,11 @@
               <div class="columns">
                 <a href="https://github.com/jwilm/alacritty">
                   <span class="link-title">alacritty-upstream</span>
-                  Upstream Github
+                  Upstream GitHub
                 </a>
                 <a href="https://github.com/chrisduerr/alacritty">
                   <span class="link-title">alacritty-fork</span>
-                  Fork Github
+                  Fork GitHub
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Just a couple of minor capitalization fixes: `Github` -> `GitHub`, `Gitlab` -> `GitLab`.

Awesome work on Alacritty btw 😄 :+1: